### PR TITLE
add optional ens resolve for current user

### DIFF
--- a/packages/app/components/Post/Post.tsx
+++ b/packages/app/components/Post/Post.tsx
@@ -1,12 +1,12 @@
-import { styled } from "@/stitches.config";
+import {styled} from "@/stitches.config";
 import Link from "next/link";
-import { useState } from "react";
-import { ClockIcon, SpeechIcon } from "@/components/Icons";
+import {ClockIcon, SpeechIcon} from "@/components/Icons";
 import Upvote from "@/components/Upvote";
 import WalletAddress from "../WalletAddress";
-import { useStore } from "@/store/store";
-import { PostProps } from "@/types";
-import { format, formatDistanceToNow, fromUnixTime } from "date-fns";
+import {useStore} from "@/store/store";
+import {PostProps} from "@/types";
+import {formatDistanceToNow, fromUnixTime} from "date-fns";
+// import {useEnsLookup} from "wagmi";
 
 const PostRow = styled("div", {
   display: "flex",
@@ -14,8 +14,6 @@ const PostRow = styled("div", {
 });
 const PostInfo = styled("div", {
   flex: 1,
-  // display: "flex",
-  // flexDirection: "column",
 });
 const Title = styled("div", {
   fontWeight: "$regular",
@@ -47,12 +45,24 @@ const IconText = styled("span", {
   "&:last-of-type:hover": {
     cursor: "pointer",
     textDecoration: "underline",
-  }
+  },
 });
 
+const Post = ({
+  id,
+  title,
+  url,
+  domainText,
+  walletAddress,
+  submissionDate,
+  numberOfComments,
+  numberOfUpvotes,
+}: PostProps) => {
+  const {upvotePost} = useStore();
 
-const Post = ({ id, title, url, domainText, walletAddress, submissionDate, numberOfComments, numberOfUpvotes }: PostProps) => {
-  const { upvotePost } = useStore();
+  // const [{data: ensName}] = useEnsLookup({
+  //   address: walletAddress,
+  // });
 
   return (
     <PostRow>
@@ -73,7 +83,10 @@ const Post = ({ id, title, url, domainText, walletAddress, submissionDate, numbe
             via{" "}
             <Link href={`/address/${walletAddress}`}>
               <a title={`View profile of ${walletAddress}`}>
-                <WalletAddress address={walletAddress} />
+                <WalletAddress
+                  address={walletAddress}
+                  // ens={ensName ? {name: ensName} : null}
+                />
               </a>
             </Link>
           </MetaAddress>

--- a/packages/app/components/WalletAuth/WalletAuth.tsx
+++ b/packages/app/components/WalletAuth/WalletAuth.tsx
@@ -1,9 +1,9 @@
-import React, { createContext, useContext, useMemo, useState } from "react";
-import { Button } from "@cabindao/topo";
+import React, {createContext, useContext, useMemo, useState} from "react";
+import {Button} from "@cabindao/topo";
 import WalletAddress from "../WalletAddress";
-import { useConnect, useAccount, Connector } from "wagmi";
+import {useConnect, useAccount, Connector} from "wagmi";
 import Link from "next/link";
-import { useRouter } from "next/router";
+import {useRouter} from "next/router";
 
 // interface WalletContextState {
 //   address: string | null;
@@ -26,8 +26,8 @@ import { useRouter } from "next/router";
 //   );
 // };
 
-export const useWallet = () => {
-  const [{ data, error }] = useAccount();
+export const useWallet = (options?: {fetchEns?: boolean}) => {
+  const [{data, error}] = useAccount(options);
   return {
     isConnected: !error && !!data?.address,
     address: data?.address ?? null,
@@ -37,16 +37,16 @@ export const useWallet = () => {
 
 const WalletAuth = () => {
   const router = useRouter();
-  const [{ data, error, loading }, connect] = useConnect();
+  const [{data, error, loading}, connect] = useConnect();
 
   const [
-    { data: accountData, error: accountError, loading: accountLoading },
+    {data: accountData, error: accountError, loading: accountLoading},
     disconnect,
   ] = useAccount();
   if (data.connected) {
     return (
       <div>
-        <Button onClick={disconnect} css={{color: "black"}} type="secondary" tone="wheat">
+        <Button onClick={disconnect} type="secondary" tone="forest">
           Disconnect
         </Button>
       </div>
@@ -56,7 +56,6 @@ const WalletAuth = () => {
   if (router.pathname === "/user/sign_in") {
     return null;
   }
-  console.log(router.pathname);
 
   return (
     <Link href="/user/sign_in" passHref>

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -4,17 +4,17 @@ import {
   defaultChains,
   useAccount,
 } from "wagmi";
-import { InjectedConnector } from "wagmi/connectors/injected";
-import { WalletConnectConnector } from "wagmi/connectors/walletConnect";
-import { styled, globalCss } from "@/stitches.config";
-import type { AppProps } from "next/app";
-import { Button } from "@cabindao/topo";
+import {InjectedConnector} from "wagmi/connectors/injected";
+import {WalletConnectConnector} from "wagmi/connectors/walletConnect";
+import {styled, globalCss} from "@/stitches.config";
+import type {AppProps} from "next/app";
+import {Button} from "@cabindao/topo";
 import WalletAddress from "@/components/WalletAddress";
 import Link from "next/link";
-import WalletAuth, { useWallet } from "@/components/WalletAuth";
-import Router, { useRouter } from "next/router";
-import { HamburgerMenuIcon, Cross1Icon } from "@radix-ui/react-icons";
-import { useEffect, useState } from "react";
+import WalletAuth, {useWallet} from "@/components/WalletAuth";
+import Router, {useRouter} from "next/router";
+import {HamburgerMenuIcon, Cross1Icon} from "@radix-ui/react-icons";
+import {useEffect, useState} from "react";
 
 const globalStyles = globalCss({
   body: {
@@ -100,16 +100,16 @@ const alchemyId = process.env.ALCHEMY_API_KEY;
 const chains = defaultChains;
 
 const connectors = [
-  new InjectedConnector({ chains: defaultChains }),
+  new InjectedConnector({chains: defaultChains}),
   new WalletConnectConnector({
     options: {
-      rpc: { 1: `https://eth-goerli.alchemyapi.io/v2/${alchemyId}}` },
+      rpc: {1: `https://eth-goerli.alchemyapi.io/v2/${alchemyId}}`},
     },
   }),
 ];
 
 const ProfileLink = () => {
-  const { address, ens } = useWallet();
+  const {address, ens} = useWallet({fetchEns: true});
   if (!address) return null;
   return (
     <Link href="/profile">
@@ -121,7 +121,7 @@ const ProfileLink = () => {
 };
 
 const SubmitLinkAction = () => {
-  const { isConnected } = useWallet();
+  const {isConnected} = useWallet();
   if (isConnected) {
     return (
       <Link href="/submission/new" passHref>
@@ -200,7 +200,7 @@ const MenuBox = styled("div", {
 });
 const MobileMenu = () => {
   const router = useRouter();
-  const [{ data }, disconnect] = useAccount();
+  const [{data}, disconnect] = useAccount();
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
@@ -237,8 +237,8 @@ const MobileMenu = () => {
               <Link href="/submission/new">
                 <a>Submit a Link</a>
               </Link>
-              <a
-                href="/"
+              <Button
+                type="link"
                 onClick={(e) => {
                   e.preventDefault();
                   setIsOpen(false);
@@ -246,7 +246,7 @@ const MobileMenu = () => {
                 }}
               >
                 Disconnect
-              </a>
+              </Button>
             </>
           ) : (
             <Link href="/user/sign_in">
@@ -277,9 +277,9 @@ const ResponsiveNav = () => {
   );
 };
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({Component, pageProps}: AppProps) {
   globalStyles();
-  const { pathname } = useRouter();
+  const {pathname} = useRouter();
   return (
     <WalletProvider autoConnect connectors={connectors}>
       <MainContainer>

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -1,14 +1,14 @@
-import type { NextPage } from "next";
-import { useState, useEffect, useMemo } from "react";
-import { DoubleArrowUpIcon, SunIcon, TargetIcon } from "@radix-ui/react-icons";
-import { styled } from "@/stitches.config";
+import type {NextPage} from "next";
+import {useState, useEffect, useMemo} from "react";
+import {DoubleArrowUpIcon, SunIcon, TargetIcon} from "@radix-ui/react-icons";
+import {styled} from "@/stitches.config";
 import Card from "@/components/Card";
 import UserCard from "@/components/UserCard";
 import PostList from "@/components/PostList";
-import { useWallet } from "@/components/WalletAuth";
-import { Select } from "@cabindao/topo";
-import { useStore } from "@/store/store";
-import AppState, { Sort } from "@/types";
+import {useWallet} from "@/components/WalletAuth";
+import {Select} from "@cabindao/topo";
+import {useStore} from "@/store/store";
+import AppState, {Sort} from "@/types";
 import DropdownMenu from "@/components/DropdownMenu";
 
 const Title = styled("h2", {
@@ -54,7 +54,7 @@ const TabLink = styled("button", {
   },
 });
 const TabButton = (props: any) => <TabLink {...props} />;
-const TabBar = ({ children, ...props }: { children?: React.ReactNode }) => {
+const TabBar = ({children, ...props}: {children?: React.ReactNode}) => {
   return (
     <TabBarWrapper {...props}>
       <TabBarContent {...props}>{children}</TabBarContent>
@@ -97,8 +97,8 @@ const StickyTabBar = styled(TabBar, {
   },
 });
 const Home: NextPage = () => {
-  const { address, ens } = useWallet();
-  const { posts, sort, updateSort } = useStore();
+  const {address, ens} = useWallet({fetchEns: true});
+  const {posts, sort, updateSort} = useStore();
   const [activeTab, setActiveTab] = useState(0);
   const [scrolled, setScrolled] = useState(false);
   const handleScroll = () => {
@@ -113,9 +113,9 @@ const Home: NextPage = () => {
   const leftNav = useMemo(() => {
     if (address) {
       return [
-        { label: "Links", value: "links" },
-        { label: "Submissions", value: "submissions" },
-        { label: "Upvotes", value: "upvotes" },
+        {label: "Links", value: "links"},
+        {label: "Submissions", value: "submissions"},
+        {label: "Upvotes", value: "upvotes"},
       ];
     }
     return [

--- a/packages/app/pages/profile/index.tsx
+++ b/packages/app/pages/profile/index.tsx
@@ -1,7 +1,7 @@
 import Card from "@/components/Card";
 import UserCard from "@/components/UserCard";
-import { useWallet } from "@/components/WalletAuth";
-import { useEffect } from "react";
+import {useWallet} from "@/components/WalletAuth";
+import {useEffect} from "react";
 
 const UnknownUser = () => {
   return (
@@ -12,7 +12,7 @@ const UnknownUser = () => {
 };
 
 const Profile = () => {
-  const { address } = useWallet();
+  const {address, ens} = useWallet();
 
   if (!address) {
     return <UnknownUser />;
@@ -21,7 +21,7 @@ const Profile = () => {
   return (
     <div>
       <Card>
-        <UserCard address={address} />
+        <UserCard address={address} ens={ens} />
       </Card>
     </div>
   );


### PR DESCRIPTION
adds an optional `useWallet({fetchEns: true})` for places we want to use ens

(optional due to the amount of requests made, we probably want these on posts too, or we could do the lookup on the server to reduce total requests)

note: ens won't resolve if you are over the api limit