### PR TITLE
feat(profile): #227 add profile page and address routes

### DIFF
--- a/packages/app/components/Profile/Profile.tsx
+++ b/packages/app/components/Profile/Profile.tsx
@@ -1,20 +1,25 @@
 import Card from "@/components/Card";
 import UserCard from "@/components/UserCard";
-import { useWallet } from "@/components/WalletAuth";
+import {useWallet} from "@/components/WalletAuth";
 import Title from "@/components/Title";
-import { v4 as uuidv4 } from "uuid";
-import { useStore, Profile } from "@/store/store";
-import { useEffect, useState } from "react";
+import {v4 as uuidv4} from "uuid";
+import {useStore, Profile} from "@/store/store";
+import {useEffect, useState} from "react";
 import supabase from "@/lib/supabaseClient";
-import { getUnixTime } from "date-fns";
+import {getUnixTime} from "date-fns";
 
 const Profile = () => {
-  const { loadProfileIntoStore, currentProfile } = useStore();
-  const { address, ens } = useWallet({ fetchEns: true });
+  const {loadProfileIntoStore, currentProfile} = useStore();
+  const {address, ens} = useWallet({fetchEns: true});
 
   useEffect(() => {
     const checkProfileExistance = async (walletAddress: string) => {
-      const { data, error } = await supabase.from<Profile>("Profiles").select("*").eq("walletAddress", walletAddress).limit(1).single();
+      const {data, error} = await supabase
+        .from<Profile>("Profiles")
+        .select("*")
+        .eq("walletAddress", walletAddress)
+        .limit(1)
+        .single();
       if (data === null) {
         const profile: Profile = {
           _id: uuidv4(),
@@ -27,7 +32,12 @@ const Profile = () => {
         await supabase.from("Profiles").insert(profile);
         loadProfileIntoStore(profile);
       } else {
-        const { data: profile } = await supabase.from<Profile>("Profiles").update({ lastSeenDate: getUnixTime(new Date()) }).eq("walletAddress", walletAddress).limit(1).single();
+        const {data: profile} = await supabase
+          .from<Profile>("Profiles")
+          .update({lastSeenDate: getUnixTime(new Date())})
+          .eq("walletAddress", walletAddress)
+          .limit(1)
+          .single();
         if (profile === null) {
           console.log("Error: ", error);
         } else {
@@ -37,7 +47,7 @@ const Profile = () => {
     };
     if (address) {
       checkProfileExistance(address);
-    };
+    }
   }, [address, loadProfileIntoStore]);
   return (
     <>

--- a/packages/app/components/TabBar/TabBar.tsx
+++ b/packages/app/components/TabBar/TabBar.tsx
@@ -1,10 +1,10 @@
-import { styled } from "@/stitches.config";
-import { useWallet } from "@/components/WalletAuth";
-import { Select } from "@cabindao/topo"
-import { useState, useMemo } from "react";
-import { useStore } from "@/store/store";
+import {styled} from "@/stitches.config";
+import {useWallet} from "@/components/WalletAuth";
+import {Select} from "@cabindao/topo";
+import React, {useState, useMemo, useEffect} from "react";
+import {useStore} from "@/store/store";
 import DropdownMenu from "@/components/DropdownMenu";
-import { DoubleArrowUpIcon, SunIcon, TargetIcon } from "@radix-ui/react-icons";
+import {DoubleArrowUpIcon, SunIcon, TargetIcon} from "@radix-ui/react-icons";
 
 const TabBarWrapper = styled("div", {
   boxSizing: "border-box",
@@ -15,7 +15,8 @@ const TabBarContent = styled("div", {
   marginBottom: -1,
   alignItems: "flex-end",
 });
-const TabLink = styled("button", {
+
+export const TabLink = styled("button", {
   boxSizing: "border-box",
   height: "$10",
   background: "none",
@@ -43,137 +44,21 @@ const TabLink = styled("button", {
 
 export type Sort = "newest" | "trending" | "controversial";
 
-export const TabButton = (props: any) => <TabLink {...props} />;
-const TabBar = ({ children, ...props }: { children?: React.ReactNode }) => {
-  const { sort, updateSort } = useStore();
-  const { address } = useWallet({ fetchEns: true });
-  const [activeTab, setActiveTab] = useState(0);
-    const leftNav = useMemo(() => {
-      if (address) {
-        return [
-          { label: "Links", value: "links" },
-          { label: "Submissions", value: "submissions" },
-          { label: "Upvotes", value: "upvotes" },
-        ];
-      }
-      return [
-        {
-          label: "Links",
-          value: "links",
-        },
-      ];
-    }, [address]);
+const TabsContainer = ({
+  className,
+  children,
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) => {
   return (
-    <TabBarWrapper {...props}>
-      <TabBarContent {...props}>
-        <MobileTabs>
-          {leftNav.length === 1 ? (
-            <TabButton active>{leftNav[0].label}</TabButton>
-          ) : (
-            <DropdownMenu
-              active
-              options={leftNav}
-              value={leftNav[activeTab]?.value}
-              onChange={(val) =>
-                setActiveTab(leftNav.findIndex((opt) => opt.value === val))
-              }
-            />
-          )}
-        </MobileTabs>
-        <DesktopTabs>
-          {!address && (
-            <TabButton
-              active={activeTab == 0 ? true : false}
-              onClick={() => setActiveTab(0)}
-            >
-              Links
-            </TabButton>
-          )}
-          {address && (
-            <>
-              <TabButton
-                active={activeTab == 0 ? true : false}
-                onClick={() => setActiveTab(0)}
-              >
-                Links
-              </TabButton>
-              <TabButton
-                active={activeTab == 1 ? true : false}
-                onClick={() => setActiveTab(1)}
-              >
-                Submissions
-              </TabButton>
-              <TabButton
-                active={activeTab == 2 ? true : false}
-                onClick={() => setActiveTab(2)}
-              >
-                Upvotes
-              </TabButton>
-              {/* <TabButton
-                active={activeTab == 3 ? true : false}
-                onClick={() => setActiveTab(3)}
-              >
-                Comments
-              </TabButton> */}
-            </>
-          )}
-        </DesktopTabs>
-        <div
-          style={{
-            marginLeft: "auto",
-            display: "flex",
-          }}
-        >
-          <DropdownMenu
-            options={[
-              {
-                value: "newest",
-                label: (
-                  <>
-                    <SunIcon /> Newest
-                  </>
-                ),
-              },
-              {
-                value: "trending",
-                label: (
-                  <>
-                    <DoubleArrowUpIcon /> Trending
-                  </>
-                ),
-              },
-              {
-                value: "controversial",
-                label: (
-                  <>
-                    <TargetIcon /> Controversial
-                  </>
-                ),
-              },
-            ]}
-            value={sort}
-            onChange={(key: Sort) => updateSort(key)}
-          />
-        </div>
-      </TabBarContent>
+    <TabBarWrapper className={className}>
+      <TabBarContent>{children}</TabBarContent>
     </TabBarWrapper>
   );
 };
 
-const MobileTabs = styled("div", {
-  display: "block",
-  "@sm": {
-    display: "none",
-  },
-});
-const DesktopTabs = styled("div", {
-  display: "none",
-  "@sm": {
-    display: "block",
-  },
-});
-
-const StickyTabBar = styled(TabBar, {
+const StickyContainer = styled(TabsContainer, {
   backgroundColor: "$sand",
   borderBottomWidth: 1,
   borderBottomStyle: "solid",
@@ -195,4 +80,162 @@ const StickyTabBar = styled(TabBar, {
   },
 });
 
-export default StickyTabBar;
+export const StickyTabBar = ({
+  className,
+  children,
+}: {
+  className?: string;
+  children?: React.ReactNode;
+}) => {
+  const [scrolled, setScrolled] = useState(false);
+
+  const handleScroll = () => {
+    const offset = window.scrollY;
+    setScrolled(offset > 200);
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  });
+
+  return (
+    <StickyContainer
+      className={className}
+      position={scrolled ? "sticky" : "fixed"}
+    >
+      {children}
+    </StickyContainer>
+  );
+};
+
+const TabBar = ({className}: {className?: string}) => {
+  const {sort, updateSort} = useStore();
+  const {address} = useWallet({fetchEns: true});
+  const [activeTab, setActiveTab] = useState(0);
+  const leftNav = useMemo(() => {
+    if (address) {
+      return [
+        {label: "Links", value: "links"},
+        {label: "Submissions", value: "submissions"},
+        {label: "Upvotes", value: "upvotes"},
+      ];
+    }
+    return [
+      {
+        label: "Links",
+        value: "links",
+      },
+    ];
+  }, [address]);
+  return (
+    <StickyTabBar className={className}>
+      <MobileTabs>
+        {leftNav.length === 1 ? (
+          <TabLink active>{leftNav[0].label}</TabLink>
+        ) : (
+          <DropdownMenu
+            active
+            options={leftNav}
+            value={leftNav[activeTab]?.value}
+            onChange={(val) =>
+              setActiveTab(leftNav.findIndex((opt) => opt.value === val))
+            }
+          />
+        )}
+      </MobileTabs>
+      <DesktopTabs>
+        {!address && (
+          <TabLink
+            active={activeTab == 0 ? true : false}
+            onClick={() => setActiveTab(0)}
+          >
+            Links
+          </TabLink>
+        )}
+        {address && (
+          <>
+            <TabLink
+              active={activeTab == 0 ? true : false}
+              onClick={() => setActiveTab(0)}
+            >
+              Links
+            </TabLink>
+            <TabLink
+              active={activeTab == 1 ? true : false}
+              onClick={() => setActiveTab(1)}
+            >
+              Submissions
+            </TabLink>
+            <TabLink
+              active={activeTab == 2 ? true : false}
+              onClick={() => setActiveTab(2)}
+            >
+              Upvotes
+            </TabLink>
+            {/* <TabButton
+                active={activeTab == 3 ? true : false}
+                onClick={() => setActiveTab(3)}
+              >
+                Comments
+              </TabButton> */}
+          </>
+        )}
+      </DesktopTabs>
+      <div
+        style={{
+          marginLeft: "auto",
+          display: "flex",
+        }}
+      >
+        <DropdownMenu
+          options={[
+            {
+              value: "newest",
+              label: (
+                <>
+                  <SunIcon /> Newest
+                </>
+              ),
+            },
+            {
+              value: "trending",
+              label: (
+                <>
+                  <DoubleArrowUpIcon /> Trending
+                </>
+              ),
+            },
+            {
+              value: "controversial",
+              label: (
+                <>
+                  <TargetIcon /> Controversial
+                </>
+              ),
+            },
+          ]}
+          value={sort}
+          onChange={(key: Sort) => updateSort(key)}
+        />
+      </div>
+    </StickyTabBar>
+  );
+};
+
+const MobileTabs = styled("div", {
+  display: "block",
+  "@sm": {
+    display: "none",
+  },
+});
+const DesktopTabs = styled("div", {
+  display: "none",
+  "@sm": {
+    display: "block",
+  },
+});
+
+export default TabBar;

--- a/packages/app/components/UserCard/UserCard.tsx
+++ b/packages/app/components/UserCard/UserCard.tsx
@@ -30,7 +30,7 @@ const UserStat = styled("div", {
 interface UserCardProps {
   address: string;
   ens?: {
-    name: string;
+    name: string | null;
     avatar?: string | null;
   } | null;
   joinDate: number;

--- a/packages/app/components/WalletAddress/WalletAddress.tsx
+++ b/packages/app/components/WalletAddress/WalletAddress.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from "react";
+import {useMemo} from "react";
 
-import { styled } from "@/stitches.config";
+import {styled} from "@/stitches.config";
 
 const AddressText = styled("span", {
   fontFamily: "$mono",
-  '&:hover': {
+  "&:hover": {
     textDecoration: "underline",
   },
 });
@@ -13,11 +13,11 @@ export interface WalletAddressProps
   extends React.ComponentProps<typeof AddressText> {
   address: string;
   ens?: {
-    name: string;
+    name: string | null;
     avatar?: string | null;
   } | null;
 }
-const WalletAddress = ({ address, ens, ...props }: WalletAddressProps) => {
+const WalletAddress = ({address, ens, ...props}: WalletAddressProps) => {
   const addr = useMemo(() => {
     return [address.slice(0, 6), address.slice(-4)].join("...");
   }, [address]);

--- a/packages/app/components/WalletAuth/WalletAuth.tsx
+++ b/packages/app/components/WalletAuth/WalletAuth.tsx
@@ -25,10 +25,10 @@ export const useWallet = (options?: {fetchEns?: boolean}) => {
   });
 
   useEffect(() => {
-    if (options?.fetchEns && ensData) {
+    if (!ens && options?.fetchEns && ensData) {
       setEns(ensData);
     }
-  }, [options?.fetchEns, ensData, setEns]);
+  }, [ens, options?.fetchEns, ensData, setEns]);
 
   return {
     isConnected: !error && !!data?.address,

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -11,11 +11,11 @@ import type {AppProps} from "next/app";
 import {Button} from "@cabindao/topo";
 import WalletAddress from "@/components/WalletAddress";
 import Link from "next/link";
-import WalletAuth, { useWallet } from "@/components/WalletAuth";
-import Router, { useRouter } from "next/router";
-import { HamburgerMenuIcon, Cross1Icon } from "@radix-ui/react-icons";
-import { useEffect, useState } from "react";
-import { useCreateStore, Provider as ZustandProvider } from "@/store/store";
+import WalletAuth, {useWallet} from "@/components/WalletAuth";
+import Router, {useRouter} from "next/router";
+import {HamburgerMenuIcon, Cross1Icon} from "@radix-ui/react-icons";
+import {useEffect, useState} from "react";
+import {useCreateStore, Provider as ZustandProvider} from "@/store/store";
 
 const globalStyles = globalCss({
   body: {
@@ -113,7 +113,7 @@ const ProfileLink = () => {
   const {address, ens} = useWallet({fetchEns: true});
   if (!address) return null;
   return (
-    <Link href="/profile">
+    <Link href="/user/profile">
       <a>
         <WalletAddress address={address} ens={ens} />
       </a>
@@ -232,7 +232,7 @@ const MobileMenu = () => {
           </Link>
           {data?.address ? (
             <>
-              <Link href="/profile">
+              <Link href="/user/profile">
                 <a>Profile</a>
               </Link>
               <Link href="/submission/new">
@@ -265,7 +265,11 @@ const ResponsiveNav = () => {
     <>
       <DesktopWrapper>
         <Nav>
-          <Button type="link">LINKS</Button>
+          <Link href="/" passHref>
+            <a>
+              <Button type="link">Home</Button>
+            </a>
+          </Link>
           <ProfileLink />
         </Nav>
         <UserActions>
@@ -278,7 +282,7 @@ const ResponsiveNav = () => {
   );
 };
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({Component, pageProps}: AppProps) {
   const createStore = useCreateStore(pageProps.initialZustandState);
   globalStyles();
   const {pathname} = useRouter();
@@ -301,7 +305,8 @@ function MyApp({ Component, pageProps }: AppProps) {
             {/* <Logo variant="logomark" color="sprout" /> */}
             <div>cabin logo</div>
             <FooterHeading>
-              Made with care by <a href="https://www.creatorcabins.com/">Cabin</a>
+              Made with care by{" "}
+              <a href="https://www.creatorcabins.com/">Cabin</a>
             </FooterHeading>
             <FooterSubtitle>
               Special thanks to creators Xxxx, Xxxx, Xxxx, &amp; more.
@@ -314,5 +319,3 @@ function MyApp({ Component, pageProps }: AppProps) {
 }
 
 export default MyApp;
-
-

--- a/packages/app/pages/address/[address].tsx
+++ b/packages/app/pages/address/[address].tsx
@@ -1,0 +1,42 @@
+import {useRouter} from "next/router";
+
+import {StickyTabBar, TabLink} from "@/components/TabBar";
+import WalletAddress from "@/components/WalletAddress";
+import {useStore} from "@/store/store";
+import PostList from "@/components/PostList";
+
+export const getServerSideProps = async ({
+  params,
+}: {
+  params: {address: string};
+}) => {
+  const {address} = params;
+  const isValid = address && address.length === 42;
+
+  return {props: {isValid}};
+};
+
+export default function Address({isValid}: {isValid: boolean}) {
+  const router = useRouter();
+  const {address} = router.query;
+
+  const {posts, sort} = useStore();
+
+  if (!isValid) {
+    return <div>Address not found.</div>;
+  }
+
+  // get posts submitted by user
+  return (
+    <div>
+      <div>
+        <WalletAddress address={address as string} />
+      </div>
+      <StickyTabBar>
+        <TabLink active>Submissions</TabLink>
+      </StickyTabBar>
+
+      <PostList posts={posts} sort={sort} />
+    </div>
+  );
+}

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -1,41 +1,20 @@
-import type { NextPage } from "next";
-import { useState, useEffect, useMemo } from "react";
+import type {NextPage} from "next";
+import {useState, useEffect, useMemo} from "react";
 import PostList from "@/components/PostList";
-import { useWallet } from "@/components/WalletAuth";
-import { useStore } from "@/store/store";
+import {useStore} from "@/store/store";
 import Title from "@/components/Title";
-import ClientSide from "@/components/HOC/ClientSide";
-import Profile from "@/components/Profile";
 import StickyTabBar from "@/components/TabBar";
 
 const Home: NextPage = () => {
-  const { posts, sort } = useStore();
-  const [activeTab, setActiveTab] = useState(0);
-  const [scrolled, setScrolled] = useState(false);
+  const {posts, sort} = useStore();
 
-  const handleScroll = () => {
-    const offset = window.scrollY;
-    if (offset > 200) {
-      setScrolled(true);
-    } else {
-      setScrolled(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener("scroll", handleScroll);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    }
-  });
   return (
-    <ClientSide>
-      <Profile />
+    <div>
+      {/* <Profile /> */}
       <Title>Today</Title>
-      <StickyTabBar position={scrolled ? "sticky" : "fixed"} />
+      <StickyTabBar />
       <PostList posts={posts} sort={sort} />
-    </ClientSide>
+    </div>
   );
 };
 
@@ -43,24 +22,28 @@ export default Home;
 
 export async function getStaticProps() {
   const initSupabaseClient = async () => {
-    const { createClient } = await import('@supabase/supabase-js');
+    const {createClient} = await import("@supabase/supabase-js");
     const supabaseId = process.env.NEXT_PUBLIC_SUPABASE_KEY || "";
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
     const supabase = createClient(supabaseUrl, supabaseId, {
-    schema: 'public',
-    autoRefreshToken: false,
-    persistSession: false,
-    detectSessionInUrl: false,
+      schema: "public",
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
     });
     return supabase;
-  }
+  };
   const supabase = await initSupabaseClient();
-  let {data: posts, error: postsError} = await supabase.from("Posts").select('*');
+  let {data: posts, error: postsError} = await supabase
+    .from("Posts")
+    .select("*");
   if (posts === null) {
     console.log(postsError);
     posts = [];
-  } 
-  let {data: upvotes, error: upvotesError} = await supabase.from("Upvotes").select('*');
+  }
+  let {data: upvotes, error: upvotesError} = await supabase
+    .from("Upvotes")
+    .select("*");
   if (upvotes === null) {
     console.log(upvotesError);
     upvotes = [];
@@ -70,7 +53,7 @@ export async function getStaticProps() {
       initialZustandState: {
         posts,
         upvotes,
-      }
+      },
     },
     revalidate: 10,
   };

--- a/packages/app/pages/user/profile.tsx
+++ b/packages/app/pages/user/profile.tsx
@@ -1,0 +1,26 @@
+import PostList from "@/components/PostList";
+import ProfileCard from "@/components/Profile";
+import {StickyTabBar, TabLink} from "@/components/TabBar";
+import {useStore} from "@/store/store";
+import {useState} from "react";
+
+export default function Profile() {
+  const {posts, sort} = useStore();
+  const [activeTab, setActiveTab] = useState(0);
+
+  return (
+    <div>
+      <ProfileCard />
+      <StickyTabBar>
+        <TabLink active={activeTab === 0} onClick={() => setActiveTab(0)}>
+          Submitted
+        </TabLink>
+        <TabLink active={activeTab === 1} onClick={() => setActiveTab(1)}>
+          Upvotes
+        </TabLink>
+      </StickyTabBar>
+
+      <PostList posts={posts} sort={sort} />
+    </div>
+  );
+}

--- a/packages/app/store/store.ts
+++ b/packages/app/store/store.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from "react";
+import {useLayoutEffect} from "react";
 import create from "zustand";
 import createContext from "zustand/context";
 
@@ -16,13 +16,13 @@ export interface Post {
 }
 export type PostList = Post[];
 export type Sort = "newest" | "trending" | "controversial";
-export type Profile =  {
-  _id: string ;
-  walletAddress: string ;
-  joinDate: number ;
-  lastSeenDate: number ;
-  upvotesReceived: number ;
-  postsUpvoted: number ;
+export type Profile = {
+  _id: string;
+  walletAddress: string;
+  joinDate: number;
+  lastSeenDate: number;
+  upvotesReceived: number;
+  postsUpvoted: number;
 };
 export interface Upvote {
   _id: string;
@@ -31,13 +31,15 @@ export interface Upvote {
   link: string;
 }
 export interface InitialState {
+  posts: PostList;
   sort: Sort;
   currentProfile: object;
 }
 const initialState: InitialState = {
+  posts: [],
   sort: "newest",
   currentProfile: {},
-}
+};
 
 export default interface AppState {
   posts: PostList;
@@ -57,14 +59,14 @@ export const initializeStore = (preloadedState = {}) => {
   return create((set: any) => ({
     ...initialState,
     ...preloadedState,
-    updateSort: (sort: Sort) => set({ sort }),
+    updateSort: (sort: Sort) => set({sort}),
     undoUpvotePost: (postId: string) => {
       set((state: AppState) => {
         const post = state.posts.find((post: Post) => post._id === postId);
         if (post) {
           post.upvotes = Math.max(0, post.upvotes - 1);
         }
-        return { posts: state.posts };
+        return {posts: state.posts};
       });
     },
     upvotePostinStore: (postId: string) => {
@@ -74,11 +76,11 @@ export const initializeStore = (preloadedState = {}) => {
           post.upvotes += 1;
         }
 
-        return { posts: state.posts };
+        return {posts: state.posts};
       });
     },
     loadProfileIntoStore: (profile: Profile) => {
-      set({ currentProfile: profile });
+      set({currentProfile: profile});
     },
     incrementProfilePostsUpvoted: () => {
       set((state: AppState) => {
@@ -87,13 +89,13 @@ export const initializeStore = (preloadedState = {}) => {
           profile.postsUpvoted += 1;
         }
 
-        return { currentProfile: profile };
+        return {currentProfile: profile};
       });
-    }
+    },
   }));
 };
 
-export function useCreateStore(initialState: { sort: string }) {
+export function useCreateStore(initialState: {sort: string}) {
   // For SSR & SSG, always use a new store.
   if (typeof window === "undefined") {
     return () => initializeStore(initialState);


### PR DESCRIPTION
new routes:
- `/user/profile` - view the current auth'd user's profile
- `/address/[wallet_address]` eg `/address/0x0000000000000000000000000000000000000000`

these changes don't include fetching posts specific to the page (like fetching the current user's posts or the address' posts, tbd on backend supporting this)

added caching of the ens address for the current user in the `useWallet` (con: if the auth'd wallet changes, ens won't refresh)