### PR TITLE
Add upvoting through api endpoint

### DIFF
--- a/packages/app/components/Post/Post.tsx
+++ b/packages/app/components/Post/Post.tsx
@@ -56,7 +56,7 @@ export interface PostProps {
   domainText: string;
   url: string;
   postedBy: string;
-  timestamp: number;
+  created_at: string;
   upvotes: number;
 }
 
@@ -66,7 +66,7 @@ const Post = ({
   url,
   domainText,
   postedBy,
-  timestamp,
+  created_at,
   upvotes,
 }: PostProps) => {
   const { upvotePostinStore, undoUpvotePost } = useStore();
@@ -130,7 +130,7 @@ const Post = ({
         <PostMeta>
           <IconText>
             <ClockIcon />{" "}
-            {formatDistanceToNow(timestamp * 1000, { addSuffix: true })}
+            {formatDistanceToNow(new Date(created_at), { addSuffix: true })}
           </IconText>
           {/* <IconText>
             <SpeechIcon fill={numberOfUpvotes > 0 ? true : false} />{" "}

--- a/packages/app/components/Post/Post.tsx
+++ b/packages/app/components/Post/Post.tsx
@@ -6,10 +6,7 @@ import WalletAddress from "../WalletAddress";
 import { useStore } from "@/store/store";
 import { formatDistanceToNow, fromUnixTime } from "date-fns";
 
-import supabase from "@/lib/supabaseClient";
 import { useWallet } from "../WalletAuth";
-import { v4 as uuidv4 } from "uuid";
-import { getUnixTime } from "date-fns";
 import { useMutation, useQueryClient } from "react-query";
 import { useCallback } from "react";
 

--- a/packages/app/components/PostList/PostList.tsx
+++ b/packages/app/components/PostList/PostList.tsx
@@ -1,7 +1,7 @@
-import {styled} from "@/stitches.config";
+import { styled } from "@/stitches.config";
 import Post from "../Post";
-import {useEffect} from "react";
-import {useStore} from "@/store/store";
+import { useEffect } from "react";
+import { useStore } from "@/store/store";
 import supabase from "@/lib/supabaseClient";
 
 const StyledPostList = styled("div", {
@@ -12,11 +12,11 @@ const StyledPostList = styled("div", {
 
 export interface Post {
   _id: string;
+  created_at: string;
   title: string;
   domainText: string;
   url: string;
   postedBy: string;
-  timestamp: number;
   upvotes: number;
 }
 export type Sort = "newest" | "trending" | "controversial";
@@ -25,8 +25,8 @@ export interface PostListProps {
   sort: Sort;
 }
 
-const PostList = ({posts, sort}: PostListProps) => {
-  const {currentProfile, incrementProfilePostsUpvoted} = useStore();
+const PostList = ({ posts, sort }: PostListProps) => {
+  const { currentProfile, incrementProfilePostsUpvoted } = useStore();
 
   useEffect(() => {
     const Upvotes = supabase
@@ -39,7 +39,7 @@ const PostList = ({posts, sort}: PostListProps) => {
           incrementProfilePostsUpvoted();
           await supabase
             .from("Profiles")
-            .update({postsUpvoted: currentProfile.postsUpvoted + 1})
+            .update({ postsUpvoted: currentProfile.postsUpvoted + 1 })
             .eq("walletAddress", currentProfile.walletAddress);
         }
       })

--- a/packages/app/pages/address/[address].tsx
+++ b/packages/app/pages/address/[address].tsx
@@ -1,38 +1,39 @@
-import {useRouter} from "next/router";
+import { useRouter } from "next/router";
 
-import {StickyTabBar, TabLink} from "@/components/TabBar";
+import { StickyTabBar, TabLink } from "@/components/TabBar";
 import WalletAddress from "@/components/WalletAddress";
 import PostList from "@/components/PostList";
-import {useQuery} from "react-query";
+import { useQuery } from "react-query";
 import supabase from "@/lib/supabaseClient";
 
 export const getServerSideProps = async ({
   params,
 }: {
-  params: {address: string};
+  params: { address: string };
 }) => {
-  const {address} = params;
+  const { address } = params;
   const isValid = address && address.length === 42;
 
-  return {props: {isValid}};
+  return { props: { isValid } };
 };
 
 async function fetchProfilePosts(address: string) {
-  let {data: posts, error: postsError} = await supabase
+  let { data: posts, error: postsError } = await supabase
     .from("Posts")
     .select("*")
     .filter("postedBy", "eq", address)
-    .order("timestamp", {ascending: false})
+    .order("timestamp", { ascending: false })
+    .order("_id", { ascending: true })
     .limit(25);
   return posts;
 }
 
-export default function Address({isValid}: {isValid: boolean}) {
+export default function Address({ isValid }: { isValid: boolean }) {
   const router = useRouter();
-  const {address} = router.query;
+  const { address } = router.query;
 
-  const {data: posts} = useQuery({
-    queryKey: ["addressPosts", address],
+  const { data: posts } = useQuery({
+    queryKey: ["posts", "address", address],
     queryFn: () => fetchProfilePosts(address as string),
     enabled: !!address,
   });

--- a/packages/app/pages/address/[address].tsx
+++ b/packages/app/pages/address/[address].tsx
@@ -22,7 +22,7 @@ async function fetchProfilePosts(address: string) {
     .from("Posts")
     .select("*")
     .filter("postedBy", "eq", address)
-    .order("timestamp", { ascending: false })
+    .order("created_at", { ascending: false })
     .order("_id", { ascending: true })
     .limit(25);
   return posts;

--- a/packages/app/pages/api/posts/[postId]/upvote.ts
+++ b/packages/app/pages/api/posts/[postId]/upvote.ts
@@ -1,0 +1,31 @@
+import supabase from "@/lib/supabaseClient";
+
+export default async function handler(req: any, res: any) {
+  if (req.method === "POST") {
+    const post = await supabase
+      .from<{ _id: string; upvotes: number }>("Posts")
+      .select("*")
+      .filter("_id", "eq", req.body.postId)
+      .single();
+
+    // create upvote
+    if (!post.data) {
+      return res.status(404);
+    }
+    await supabase.from("Upvotes").insert({
+      upvoter: req.body.upvoter,
+      post: req.body.postId,
+      timestamp: new Date().getTime(),
+    });
+
+    // TODO: this should be a stored function in supabase
+    await supabase
+      .from("Posts")
+      .update({ upvotes: post.data?.upvotes + 1 })
+      .match({ _id: post.data._id });
+
+    return res.json({ ...post.data, upvotes: post.data.upvotes + 1 });
+  } else {
+    return res.status(404);
+  }
+}

--- a/packages/app/pages/api/posts/[postId]/upvote.ts
+++ b/packages/app/pages/api/posts/[postId]/upvote.ts
@@ -2,30 +2,18 @@ import supabase from "@/lib/supabaseClient";
 
 export default async function handler(req: any, res: any) {
   if (req.method === "POST") {
-    const post = await supabase
-      .from<{ _id: string; upvotes: number }>("Posts")
-      .select("*")
-      .filter("_id", "eq", req.body.postId)
-      .single();
-
-    // create upvote
-    if (!post.data) {
-      return res.status(404);
-    }
-    await supabase.from("Upvotes").insert({
-      upvoter: req.body.upvoter,
-      post: req.body.postId,
-      timestamp: new Date().getTime(),
+    // TODO: verify upvoter address using signed message
+    const { error } = await supabase.rpc("upvote", {
+      post_id: req.body.postId,
+      address: req.body.upvoter,
     });
 
-    // TODO: this should be a stored function in supabase
-    await supabase
-      .from("Posts")
-      .update({ upvotes: post.data?.upvotes + 1 })
-      .match({ _id: post.data._id });
+    if (error) {
+      return res.status(409).json({ message: "Already upvoted" });
+    }
 
-    return res.json({ ...post.data, upvotes: post.data.upvotes + 1 });
+    return res.status(201).json({ postId: req.body.postId });
   } else {
-    return res.status(404);
+    return res.setHeader("ALLOWED", "POST").status(405);
   }
 }

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -8,7 +8,7 @@ import supabase from "@/lib/supabaseClient";
 
 const sorting: Record<string, { column: string; ascending: boolean }> = {
   newest: {
-    column: "timestamp",
+    column: "created_at",
     ascending: false,
   },
   trending: {

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -1,12 +1,12 @@
-import type {NextPage} from "next";
+import type { NextPage } from "next";
 import PostList from "@/components/PostList";
-import {useStore} from "@/store/store";
+import { useStore } from "@/store/store";
 import Title from "@/components/Title";
 import StickyTabBar from "@/components/TabBar";
-import {useQuery} from "react-query";
+import { useQuery } from "react-query";
 import supabase from "@/lib/supabaseClient";
 
-const sorting: Record<string, {column: string; ascending: boolean}> = {
+const sorting: Record<string, { column: string; ascending: boolean }> = {
   newest: {
     column: "timestamp",
     ascending: false,
@@ -21,17 +21,19 @@ async function loadPosts(sort: string) {
   let query = supabase.from("Posts").select("*").limit(25);
 
   if (sorting[sort]) {
-    query = query.order(sorting[sort].column, {
-      ascending: sorting[sort].ascending,
-    });
+    query = query
+      .order(sorting[sort].column, {
+        ascending: sorting[sort].ascending,
+      })
+      .order("_id", { ascending: true });
   }
-  const {data: posts, error: postsError} = await query;
+  const { data: posts, error: postsError } = await query;
   return posts;
 }
 
 const Home: NextPage = () => {
-  const {sort} = useStore();
-  const {data: posts} = useQuery(["posts", sort], () => loadPosts(sort));
+  const { sort } = useStore();
+  const { data: posts } = useQuery(["posts", sort], () => loadPosts(sort));
 
   return (
     <div>
@@ -46,7 +48,7 @@ export default Home;
 
 export async function getStaticProps() {
   const initSupabaseClient = async () => {
-    const {createClient} = await import("@supabase/supabase-js");
+    const { createClient } = await import("@supabase/supabase-js");
     const supabaseId = process.env.NEXT_PUBLIC_SUPABASE_KEY || "";
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
     const supabase = createClient(supabaseUrl, supabaseId, {
@@ -58,7 +60,7 @@ export async function getStaticProps() {
     return supabase;
   };
   const supabase = await initSupabaseClient();
-  let {data: upvotes, error: upvotesError} = await supabase
+  let { data: upvotes, error: upvotesError } = await supabase
     .from("Upvotes")
     .select("*");
   if (upvotes === null) {

--- a/packages/app/pages/user/profile.tsx
+++ b/packages/app/pages/user/profile.tsx
@@ -13,7 +13,7 @@ interface Post {
   url: string;
   postedBy: string;
   upvotes: number;
-  timestamp: number;
+  created_at: string;
   domainText: string;
 }
 
@@ -22,7 +22,7 @@ async function fetchProfilePosts(address: string) {
     .from<Post>("Posts")
     .select("*")
     .filter("postedBy", "eq", address)
-    .order("timestamp", { ascending: false })
+    .order("created_at", { ascending: false })
     .order("_id", { ascending: true })
     .limit(25);
   return posts;

--- a/packages/app/pages/user/profile.tsx
+++ b/packages/app/pages/user/profile.tsx
@@ -23,6 +23,7 @@ async function fetchProfilePosts(address: string) {
     .select("*")
     .filter("postedBy", "eq", address)
     .order("timestamp", { ascending: false })
+    .order("_id", { ascending: true })
     .limit(25);
   return posts;
 }
@@ -31,7 +32,7 @@ export default function Profile() {
   const { address } = useWallet();
   const [activeTab, setActiveTab] = useState(0);
   const { data: posts } = useQuery({
-    queryKey: ["addressPosts", address],
+    queryKey: ["posts", "address", address],
     queryFn: () => fetchProfilePosts(address as string),
     enabled: !!address,
   });

--- a/packages/app/pages/user/profile.tsx
+++ b/packages/app/pages/user/profile.tsx
@@ -1,10 +1,10 @@
 import PostList from "@/components/PostList";
 import ProfileCard from "@/components/Profile";
-import {StickyTabBar, TabLink} from "@/components/TabBar";
-import {useWallet} from "@/components/WalletAuth";
+import { StickyTabBar, TabLink } from "@/components/TabBar";
+import { useWallet } from "@/components/WalletAuth";
 import supabase from "@/lib/supabaseClient";
-import {useState} from "react";
-import {useQuery} from "react-query";
+import { useState } from "react";
+import { useQuery } from "react-query";
 
 interface Post {
   _id: string;
@@ -18,22 +18,21 @@ interface Post {
 }
 
 async function fetchProfilePosts(address: string) {
-  let {data: posts, error: postsError} = await supabase
+  let { data: posts, error: postsError } = await supabase
     .from<Post>("Posts")
     .select("*")
     .filter("postedBy", "eq", address)
-    .order("timestamp", {ascending: false})
+    .order("timestamp", { ascending: false })
     .limit(25);
   return posts;
 }
 
 export default function Profile() {
-  const {address} = useWallet();
+  const { address } = useWallet();
   const [activeTab, setActiveTab] = useState(0);
-  const {data: posts} = useQuery({
+  const { data: posts } = useQuery({
     queryKey: ["addressPosts", address],
     queryFn: () => fetchProfilePosts(address as string),
-    cacheTime: 60_000, // cache for 1 minute
     enabled: !!address,
   });
 

--- a/packages/app/store/store.ts
+++ b/packages/app/store/store.ts
@@ -1,4 +1,4 @@
-import {useLayoutEffect} from "react";
+import { useLayoutEffect } from "react";
 import create from "zustand";
 import createContext from "zustand/context";
 
@@ -11,6 +11,7 @@ export interface Post {
   domainText: string;
   url: string;
   postedBy: string;
+  created_at: string;
   timestamp: number;
   upvotes: number;
 }
@@ -28,6 +29,7 @@ export interface Upvote {
   _id: string;
   upvoter: string;
   timestamp: number;
+  created_at: string;
   link: string;
 }
 export interface InitialState {
@@ -56,7 +58,7 @@ export const initializeStore = (preloadedState = {}) => {
   return create((set: any) => ({
     ...initialState,
     ...preloadedState,
-    updateSort: (sort: Sort) => set({sort}),
+    updateSort: (sort: Sort) => set({ sort }),
     undoUpvotePost: (postId: string) => {
       // TODO: implement this server-side with signed message verification
       // set((state: AppState) => {
@@ -78,7 +80,7 @@ export const initializeStore = (preloadedState = {}) => {
       // });
     },
     loadProfileIntoStore: (profile: Profile) => {
-      set({currentProfile: profile});
+      set({ currentProfile: profile });
     },
     incrementProfilePostsUpvoted: () => {
       set((state: AppState) => {
@@ -87,13 +89,13 @@ export const initializeStore = (preloadedState = {}) => {
           profile.postsUpvoted += 1;
         }
 
-        return {currentProfile: profile};
+        return { currentProfile: profile };
       });
     },
   }));
 };
 
-export function useCreateStore(initialState: {sort: string}) {
+export function useCreateStore(initialState: { sort: string }) {
   // For SSR & SSG, always use a new store.
   if (typeof window === "undefined") {
     return () => initializeStore(initialState);


### PR DESCRIPTION
add api route `POST /api/posts/[postId]/upvote`  to upvote a post (secondary ordering by _id to ensure consistent sort order)

- [x] ensure an address can't upvote multiple times on a post
- [x] also should use a supabase postgres function to handle incrementing the upvote count and inserting an upvote record

later we will need to add something to ensure that the upvote is by the address owner (via signed message) https://app.clarity.so/cabin/work/547