### PR TITLE
default sort to trending, sort using post_rankings view

### DIFF
--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -12,13 +12,18 @@ const sorting: Record<string, { column: string; ascending: boolean }> = {
     ascending: false,
   },
   trending: {
-    column: "upvotes",
+    column: "score",
     ascending: false,
   },
 };
 
+// TODO: if sort by newest
 async function loadPosts(sort: string) {
-  let query = supabase.from("Posts").select("*").limit(25);
+  // load posts by ranking if sort === 'trending'
+  let query =
+    sort === "trending"
+      ? supabase.from("post_rankings").select("*").limit(25)
+      : supabase.from("Posts").select("*").limit(25);
 
   if (sorting[sort]) {
     query = query

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -1,12 +1,12 @@
-import type { NextPage } from "next";
+import type {NextPage} from "next";
 import PostList from "@/components/PostList";
-import { useStore } from "@/store/store";
+import {useStore} from "@/store/store";
 import Title from "@/components/Title";
 import StickyTabBar from "@/components/TabBar";
-import { useQuery } from "react-query";
+import {useQuery} from "react-query";
 import supabase from "@/lib/supabaseClient";
 
-const sorting: Record<string, { column: string; ascending: boolean }> = {
+const sorting: Record<string, {column: string; ascending: boolean}> = {
   newest: {
     column: "created_at",
     ascending: false,
@@ -19,22 +19,25 @@ const sorting: Record<string, { column: string; ascending: boolean }> = {
 
 // TODO: if sort by newest
 async function loadPosts(sort: string) {
-  let query = supabase.from("Posts").select("*").limit(25);
+  let query =
+    sort === "trending"
+      ? supabase.from("post_rankings").select("*").limit(25)
+      : supabase.from("Posts").select("*").limit(25);
 
   if (sorting[sort]) {
     query = query
       .order(sorting[sort].column, {
         ascending: sorting[sort].ascending,
       })
-      .order("_id", { ascending: true });
+      .order("_id", {ascending: true});
   }
-  const { data: posts, error: postsError } = await query;
+  const {data: posts, error: postsError} = await query;
   return posts;
 }
 
 const Home: NextPage = () => {
-  const { sort } = useStore();
-  const { data: posts } = useQuery(["posts", sort], () => loadPosts(sort));
+  const {sort} = useStore();
+  const {data: posts} = useQuery(["posts", sort], () => loadPosts(sort));
 
   return (
     <div>
@@ -49,7 +52,7 @@ export default Home;
 
 export async function getStaticProps() {
   const initSupabaseClient = async () => {
-    const { createClient } = await import("@supabase/supabase-js");
+    const {createClient} = await import("@supabase/supabase-js");
     const supabaseId = process.env.NEXT_PUBLIC_SUPABASE_KEY || "";
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
     const supabase = createClient(supabaseUrl, supabaseId, {
@@ -61,7 +64,7 @@ export async function getStaticProps() {
     return supabase;
   };
   const supabase = await initSupabaseClient();
-  let { data: upvotes, error: upvotesError } = await supabase
+  let {data: upvotes, error: upvotesError} = await supabase
     .from("Upvotes")
     .select("*");
   if (upvotes === null) {

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -19,11 +19,7 @@ const sorting: Record<string, { column: string; ascending: boolean }> = {
 
 // TODO: if sort by newest
 async function loadPosts(sort: string) {
-  // load posts by ranking if sort === 'trending'
-  let query =
-    sort === "trending"
-      ? supabase.from("post_rankings").select("*").limit(25)
-      : supabase.from("Posts").select("*").limit(25);
+  let query = supabase.from("Posts").select("*").limit(25);
 
   if (sorting[sort]) {
     query = query

--- a/packages/app/store/store.ts
+++ b/packages/app/store/store.ts
@@ -37,7 +37,7 @@ export interface InitialState {
   currentProfile: object;
 }
 const initialState: InitialState = {
-  sort: "newest",
+  sort: "trending",
   currentProfile: {},
 };
 


### PR DESCRIPTION
Add sorting by Trending 

score is calculated using the formula: `rankingScore = pow(upvotes, 0.8) / pow(ageHours + 2, 1.8)`

- default homepage sort to Trending (sort using a materialized view `post_rankings`)
- triggers used to refresh the view and recalculate post scores 

analysis of ranking and HN: https://app.clarity.so/cabin/notes/b59e02d4-b5da-43ad-8ba1-bec4d7a322af