### PR TITLE
fix(ens): lookup ens names, store lookups in a cache

### DIFF
--- a/packages/app/components/Post/Post.tsx
+++ b/packages/app/components/Post/Post.tsx
@@ -9,6 +9,8 @@ import { formatDistanceToNow, fromUnixTime } from "date-fns";
 import { useWallet } from "../WalletAuth";
 import { useMutation, useQueryClient } from "react-query";
 import { useCallback } from "react";
+import { useProvider } from "wagmi";
+import { useEnsLookup } from "@/helpers/ens";
 
 const PostRow = styled("div", {
   display: "flex",
@@ -73,11 +75,9 @@ const Post = ({
 }: PostProps) => {
   const { address, isAuthenticated } = useWallet();
   const queryClient = useQueryClient();
-
-  const {
-    sort,
-    siwe: { address: siweAddress },
-  } = useStore();
+  const { sort } = useStore();
+  const provider = useProvider();
+  const [resolvedName] = useEnsLookup([postedBy], provider);
 
   const { mutate } = useMutation<any, Error, { postId: string }>(
     async ({ postId }) => {
@@ -156,7 +156,10 @@ const Post = ({
             via{" "}
             <Link href={`/address/${postedBy}`}>
               <a title={`View profile of ${postedBy}`}>
-                <WalletAddress address={postedBy} />
+                <WalletAddress
+                  address={postedBy}
+                  ens={{ name: resolvedName }}
+                />
               </a>
             </Link>
           </MetaAddress>

--- a/packages/app/components/PostList/PostList.tsx
+++ b/packages/app/components/PostList/PostList.tsx
@@ -25,7 +25,6 @@ export interface PostListProps {
 
 const PostList = ({ posts }: PostListProps) => {
   const { currentProfile, incrementProfilePostsUpvoted } = useStore();
-
   useEffect(() => {
     const Upvotes = supabase
       .from("Upvotes")

--- a/packages/app/components/WalletAddress/WalletAddress.tsx
+++ b/packages/app/components/WalletAddress/WalletAddress.tsx
@@ -1,6 +1,7 @@
-import {useMemo} from "react";
+import { useMemo } from "react";
 
-import {styled} from "@/stitches.config";
+import { styled } from "@/stitches.config";
+import { useEnsStore } from "@/helpers/ens";
 
 const AddressText = styled("span", {
   fontFamily: "$mono",
@@ -17,7 +18,7 @@ export interface WalletAddressProps
     avatar?: string | null;
   } | null;
 }
-const WalletAddress = ({address, ens, ...props}: WalletAddressProps) => {
+const WalletAddress = ({ address, ens, ...props }: WalletAddressProps) => {
   const addr = useMemo(() => {
     return [address.slice(0, 6), address.slice(-4)].join("...");
   }, [address]);

--- a/packages/app/helpers/ens.ts
+++ b/packages/app/helpers/ens.ts
@@ -1,0 +1,84 @@
+import create from "zustand";
+import namehash from "@ensdomains/eth-ens-namehash";
+import { useEffect, useMemo } from "react";
+import { useContract } from "wagmi";
+
+interface EnsState {
+  resolvedNames: { [address: string]: string };
+  addResolvedAddresses: (resolves: { [adress: string]: string }) => void;
+}
+export const useEnsStore = create<EnsState>((set) => ({
+  resolvedNames: {},
+  addResolvedAddresses: (resolves: { [adress: string]: string }) =>
+    set((state) => ({
+      ...state,
+      resolvedNames: { ...state.resolvedNames, ...resolves },
+    })),
+}));
+
+const abi = [
+  {
+    inputs: [{ internalType: "contract ENS", name: "_ens", type: "address" }],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [
+      { internalType: "address[]", name: "addresses", type: "address[]" },
+    ],
+    name: "getNames",
+    outputs: [{ internalType: "string[]", name: "r", type: "string[]" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+export const useEnsLookup = (
+  addresses: string[],
+  signerOrProvider: any
+): (string | null)[] => {
+  const addResolvedAddresses = useEnsStore(
+    (state) => state.addResolvedAddresses
+  );
+  // check if the ens store has all of the addresses already resolved
+  const resolvedNames = useEnsStore((state) => state.resolvedNames);
+
+  const resolvedAddresses = Object.keys(resolvedNames);
+  const unresolvedAddresses = addresses.filter(
+    (address) => !resolvedAddresses.includes(address)
+  );
+
+  const contract = useContract({
+    // mainnet ens contract for reverse lookup
+    addressOrName: "0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C",
+    contractInterface: abi,
+    signerOrProvider,
+  });
+
+  useEffect(() => {
+    (async () => {
+      if (unresolvedAddresses.length === 0) {
+        return;
+      }
+      const [allNames] = await contract.functions.getNames(unresolvedAddresses);
+      const validNames = allNames.map((n: any) => {
+        return namehash.normalize(n) === n && n !== "" ? n : null;
+      });
+
+      addResolvedAddresses(
+        validNames.reduce(
+          (acc: { [address: string]: string }, name: string, idx: number) => {
+            acc[unresolvedAddresses[idx]] = name ?? null;
+            return acc;
+          },
+          {} as { [address: string]: string }
+        )
+      );
+    })();
+  }, [addResolvedAddresses, unresolvedAddresses, contract]);
+
+  return useMemo(
+    () => addresses.map((address) => resolvedNames[address] ?? null),
+    [addresses, resolvedNames]
+  );
+};

--- a/packages/app/index.d.ts
+++ b/packages/app/index.d.ts
@@ -1,0 +1,7 @@
+declare module "@ensdomains/eth-ens-namehash" {
+  const namehash = {
+    hash: (input: string) => string,
+    normalize: (input: string) => string,
+  };
+  export default namehash;
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,7 @@
     "@types/uuid": "^8.3.4",
     "cors": "^2.8.5",
     "date-fns": "^2.28.0",
+    "@ensdomains/eth-ens-namehash": "^2.0.15",
     "ethers": "^5.5.3",
     "iron-session": "^6.0.5",
     "isomorphic-ws": "^4.0.1",

--- a/packages/app/pages/index.tsx
+++ b/packages/app/pages/index.tsx
@@ -5,7 +5,10 @@ import Title from "@/components/Title";
 import StickyTabBar from "@/components/TabBar";
 import { useQuery } from "react-query";
 import supabase from "@/lib/supabase";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
+
+import { useContract, useProvider } from "wagmi";
+import { useEnsLookup } from "@/helpers/ens";
 
 const sorting: Record<string, { column: string; ascending: boolean }> = {
   newest: {
@@ -63,6 +66,17 @@ const Home: NextPage = () => {
     window.addEventListener("focus", handler);
     return () => window.removeEventListener("focus", handler);
   }, [setSiweAddress, setSiweLoading]);
+
+  const provider = useProvider();
+
+  const addresses: string[] = useMemo(
+    () => posts?.map((p) => p.postedBy as string) ?? [],
+    [posts]
+  );
+
+  // prefetch ens names
+  useEnsLookup(addresses, provider);
+
   return (
     <div>
       <Title>Today</Title>

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,6 +244,11 @@
     testrpc "0.0.1"
     web3-utils "^1.0.0-beta.31"
 
+"@ensdomains/eth-ens-namehash@^2.0.15":
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz#5e5f2f24ba802aff8bc19edd822c9a11200cdf4a"
+  integrity sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw==
+
 "@ensdomains/resolver@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"


### PR DESCRIPTION
cache lookups for ens names, use a bulk lookup using ens contract.

closes #227

see https://docs.ens.domains/dapp-developer-guide/resolving-names#reverse-resolution for details on reverse resolution

This uses the `ReverseRecords` ens domains contract to lookup several addresses.