### PR TITLE
Chore: Capitalized `Blaze`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "blaze",
+  "name": "Blaze",
   "version": "1.0.0",
   "description": "Hacker News for DAOs",
   "main": "index.js",
-  "repository": "https://github.com/CabinDAO/blaze.git",
+  "repository": "https://github.com/CabinDAO/Blaze.git",
   "author": "@delightfulabyss",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Capitalized `Blaze` in `package.json` file.